### PR TITLE
log is not thread-safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: go
 go:
+    - 1.5.2
     - tip
 before_install:
     - go get github.com/modocache/gover
     - go get github.com/mattn/goveralls
     - go get golang.org/x/tools/cmd/cover
 script:
+    - go test -race ./...
     - go test -coverprofile=color.coverprofile ./color
     - go test -coverprofile=gytes.coverprofile ./gytes
     - go test -coverprofile=log.coverprofile ./log


### PR DESCRIPTION
Specifically, New() is not thread-safe due to use of exported color functions instead of using own Color instance. Pull request adds test to show that.