### PR TITLE
Used float32, but should use float64

### DIFF
--- a/bytes/bytes.go
+++ b/bytes/bytes.go
@@ -35,7 +35,7 @@ func New() *Bytes {
 // For example, 31323 bytes will return 30.59KB.
 func (*Bytes) Format(b int64) string {
 	multiple := ""
-	value := float32(b)
+	value := float64(b)
 
 	switch {
 	case b < KB:


### PR DESCRIPTION
gommon/byte computes 64 bit value, but use float32.
Should use float64  If computes 64bit value.