### PR TITLE
Escape strings with quotes

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -360,9 +360,9 @@ func (l *Logger) log(v Lvl, format string, args ...interface{}) {
 				if format == "json" {
 					buf.WriteString(message[1:])
 				} else {
-					buf.WriteString(`"message":"`)
-					buf.WriteString(message)
-					buf.WriteString(`"}`)
+					buf.WriteString(`"message":`)
+					buf.WriteString(strconv.Quote(message))
+					buf.WriteString(`}`)
 				}
 			} else {
 				// Text header

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -110,6 +110,15 @@ func TestJSON(t *testing.T) {
 	assert.Contains(t, b.String(), `"name":"value"`)
 }
 
+func TestStringWithQuotes(t *testing.T) {
+	l := New("test")
+	b := new(bytes.Buffer)
+	l.SetOutput(b)
+	l.SetLevel(DEBUG)
+	l.Debugf("Content-Type: %q", "")
+	assert.Contains(t, b.String(), `"message":"Content-Type: \"\""`)
+}
+
 func BenchmarkLog(b *testing.B) {
 	l := New("test")
 	l.SetOutput(new(bytes.Buffer))


### PR DESCRIPTION
The current implementation won't work if there are quotes in the string that's being logged.

`strconv.Quote` solves this issue by wrapping the supplied string in double quotes, escaping any existing quotes in the supplied string.
