### PR TITLE
gommon/log | global caller notification 

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -41,6 +41,8 @@ const (
 	WARN
 	ERROR
 	OFF
+	panicLevel
+	fatalLevel
 )
 
 var (
@@ -73,6 +75,9 @@ func (l *Logger) initLevels() {
 		l.color.Green("INFO"),
 		l.color.Yellow("WARN"),
 		l.color.Red("ERROR"),
+		"",
+		l.color.Yellow("PANIC", color.U),
+		l.color.Red("FATAL", color.U),
 	}
 }
 
@@ -187,32 +192,32 @@ func (l *Logger) Errorj(j JSON) {
 }
 
 func (l *Logger) Fatal(i ...interface{}) {
-	l.Print(i...)
+	l.log(fatalLevel, "", i...)
 	os.Exit(1)
 }
 
 func (l *Logger) Fatalf(format string, args ...interface{}) {
-	l.Printf(format, args...)
+	l.log(fatalLevel, format, args...)
 	os.Exit(1)
 }
 
 func (l *Logger) Fatalj(j JSON) {
-	l.Printj(j)
+	l.log(fatalLevel, "json", j)
 	os.Exit(1)
 }
 
 func (l *Logger) Panic(i ...interface{}) {
-	l.Print(i...)
+	l.log(panicLevel, "", i...)
 	panic(fmt.Sprint(i...))
 }
 
 func (l *Logger) Panicf(format string, args ...interface{}) {
-	l.Printf(format, args...)
+	l.log(panicLevel, format, args...)
 	panic(fmt.Sprintf(format, args))
 }
 
 func (l *Logger) Panicj(j JSON) {
-	l.Printj(j)
+	l.log(panicLevel, "json", j)
 	panic(j)
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"sync"
@@ -37,6 +38,10 @@ func test(l *Logger, t *testing.T) {
 	assert.Contains(t, b.String(), `"message":"warn"`)
 	assert.Contains(t, b.String(), `"level":"ERROR","prefix":"`+l.prefix+`"`)
 	assert.Contains(t, b.String(), `"message":"errorf"`)
+
+	if testing.Verbose() {
+		fmt.Println(b.String())
+	}
 }
 
 func TestLog(t *testing.T) {
@@ -45,7 +50,36 @@ func TestLog(t *testing.T) {
 }
 
 func TestGlobal(t *testing.T) {
-	test(global, t)
+	b := new(bytes.Buffer)
+	global.SetOutput(b)
+	global.DisableColor()
+	global.SetLevel(WARN)
+
+	Print("print")
+	Printf("print%s", "f")
+	Debug("debug")
+	Debugf("debug%s", "f")
+	Info("info")
+	Infof("info%s", "f")
+	Warn("warn")
+	Warnf("warn%s", "f")
+	Error("error")
+	Errorf("error%s", "f")
+
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"58","message":"print"`)
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"59","message":"printf"`)
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"64","message":"warn"`)
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"65","message":"warnf"`)
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"66","message":"error"`)
+	assert.Contains(t, b.String(), `"file":"log_test.go","line":"67","message":"errorf"`)
+	assert.Contains(t, b.String(), `"level":"WARN","prefix":"`+global.prefix+`"`)
+	assert.Contains(t, b.String(), `"message":"warn"`)
+	assert.Contains(t, b.String(), `"level":"ERROR","prefix":"`+global.prefix+`"`)
+	assert.Contains(t, b.String(), `"message":"errorf"`)
+
+	if testing.Verbose() {
+		fmt.Println(b.String())
+	}
 }
 
 func TestLogConcurrent(t *testing.T) {


### PR DESCRIPTION
This changes the behavior of global calls like `log.Print()` for example.

This is what happens when you display the `test` buffer.
In first place this the result of the test using the `test` function.
And then the result when you call the function directly.
```
=== RUN   TestGlobal
{"time":"2018-04-27T13:01:00.592958006+02:00","level":"-","prefix":"-","file":"log_test.go","line":"20","message":"print"}
{"time":"2018-04-27T13:01:00.59296855+02:00","level":"-","prefix":"-","file":"log_test.go","line":"21","message":"printf"}
{"time":"2018-04-27T13:01:00.592990136+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"26","message":"warn"}
{"time":"2018-04-27T13:01:00.592999838+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"27","message":"warnf"}
{"time":"2018-04-27T13:01:00.593007922+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"28","message":"error"}
{"time":"2018-04-27T13:01:00.593021023+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"29","message":"errorf"}

{"time":"2018-04-27T13:01:00.593067503+02:00","level":"-","prefix":"-","file":"log.go","line":"267","message":"print"}
{"time":"2018-04-27T13:01:00.593078668+02:00","level":"-","prefix":"-","file":"log.go","line":"271","message":"printf"}
{"time":"2018-04-27T13:01:00.593100463+02:00","level":"WARN","prefix":"-","file":"log.go","line":"303","message":"warn"}
{"time":"2018-04-27T13:01:00.593106604+02:00","level":"WARN","prefix":"-","file":"log.go","line":"307","message":"warnf"}
{"time":"2018-04-27T13:01:00.593111993+02:00","level":"ERROR","prefix":"-","file":"log.go","line":"315","message":"error"}
{"time":"2018-04-27T13:01:00.593116528+02:00","level":"ERROR","prefix":"-","file":"log.go","line":"319","message":"errorf"}

--- PASS: TestGlobal (0.00s)
```

Display the line in `log.go` is not really useful. :smile:
After this change the buffer display this: 
```
=== RUN   TestGlobal
{"time":"2018-04-27T13:04:25.063464991+02:00","level":"-","prefix":"-","file":"log_test.go","line":"53","message":"print"}
{"time":"2018-04-27T13:04:25.06347601+02:00","level":"-","prefix":"-","file":"log_test.go","line":"53","message":"printf"}
{"time":"2018-04-27T13:04:25.063489653+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"53","message":"warn"}
{"time":"2018-04-27T13:04:25.06349519+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"53","message":"warnf"}
{"time":"2018-04-27T13:04:25.063503081+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"53","message":"error"}
{"time":"2018-04-27T13:04:25.063514465+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"53","message":"errorf"}

{"time":"2018-04-27T13:04:25.063554739+02:00","level":"-","prefix":"-","file":"log_test.go","line":"60","message":"print"}
{"time":"2018-04-27T13:04:25.063565835+02:00","level":"-","prefix":"-","file":"log_test.go","line":"61","message":"printf"}
{"time":"2018-04-27T13:04:25.06358589+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"66","message":"warn"}
{"time":"2018-04-27T13:04:25.063593027+02:00","level":"WARN","prefix":"-","file":"log_test.go","line":"67","message":"warnf"}
{"time":"2018-04-27T13:04:25.063597844+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"68","message":"error"}
{"time":"2018-04-27T13:04:25.063602406+02:00","level":"ERROR","prefix":"-","file":"log_test.go","line":"69","message":"errorf"}

--- PASS: TestGlobal (0.00s)
```

We can argue the way the test is done.
Because if the file is updated the lines numbers will probably change and the test will fails.
We can maybe move it in its own test file.