### PR TITLE
Option to use json.MarshalIndent

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -110,6 +110,17 @@ func TestJSON(t *testing.T) {
 	assert.Contains(t, b.String(), `"name":"value"`)
 }
 
+func TestJSONIndent(t *testing.T) {
+	l := New("test")
+	b := new(bytes.Buffer)
+	l.SetOutput(b)
+	l.SetLevel(DEBUG)
+	l.SetHeader("")
+	l.SetIndent("  ")
+	l.Debugj(JSON{"name": "value"})
+	assert.Contains(t, b.String(), "xxx {\n  \"name\": \"value\"\n}\n")
+}
+
 func TestStringWithQuotes(t *testing.T) {
 	l := New("test")
 	b := new(bytes.Buffer)


### PR DESCRIPTION
It can be hard to read JSON logs without indentation. 

Also fixes an *index out of range* bug with `l.SetHeader("")`