### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed // indirect
 )
 
-go 1.13
+go 1.12


### PR DESCRIPTION
The go 1.13 directive makes this incompatible with the latest stable go.