### PR TITLE
Fixed error on lowercase multiple parse

### DIFF
--- a/bytes/bytes.go
+++ b/bytes/bytes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 type (
@@ -73,7 +74,7 @@ func (*Bytes) Parse(value string) (i int64, err error) {
 		return 0, fmt.Errorf("error parsing value=%s", value)
 	}
 	bytesString := parts[1]
-	multiple := parts[2]
+	multiple := strings.ToUpper(parts[2])
 	bytes, err := strconv.ParseFloat(bytesString, 64)
 	if err != nil {
 		return

--- a/bytes/bytes_test.go
+++ b/bytes/bytes_test.go
@@ -106,6 +106,21 @@ func TestBytesParse(t *testing.T) {
 		assert.Equal(t, int64(12288), b)
 	}
 
+	// kb, lowercase multiple test
+	b, err = Parse("12.25kb")
+	if assert.NoError(t, err) {
+		assert.Equal(t, int64(12544), b)
+	}
+	b, err = Parse("12kb")
+	if assert.NoError(t, err) {
+		assert.Equal(t, int64(12288), b)
+	}
+	b, err = Parse("12k")
+	if assert.NoError(t, err) {
+		assert.Equal(t, int64(12288), b)
+	}
+
+
 	// KB with space
 	b, err = Parse("12.25 KB")
 	if assert.NoError(t, err) {


### PR DESCRIPTION
bug: for example, 6gb or 6g will return 6.