### PR TITLE
do not rely on undefined behaviour in bytes_test.go

### DIFF
--- a/bytes/bytes_test.go
+++ b/bytes/bytes_test.go
@@ -206,22 +206,22 @@ func TestBytesParse(t *testing.T) {
 	}
 
 	// EB
-	b, err = Parse("8EB")
+	b, err = Parse("7EB")
 	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
+		assert.Equal(t, 7*int64(1152921504606846976), b)
 	}
-	b, err = Parse("8E")
+	b, err = Parse("7E")
 	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
+		assert.Equal(t, 7*int64(1152921504606846976), b)
 	}
 
 	// EB with spaces
-	b, err = Parse("8 EB")
+	b, err = Parse("7 EB")
 	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
+		assert.Equal(t, 7*int64(1152921504606846976), b)
 	}
-	b, err = Parse("8 E")
+	b, err = Parse("7 E")
 	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
+		assert.Equal(t, 7*int64(1152921504606846976), b)
 	}
 }


### PR DESCRIPTION
8 exbi equals 2^64, therefore it cannot be stored in int64. The tests use
the fact that on x86_64 the following expressions holds true:
int64(0) - 1 == math.MaxInt64.

However, this is not true for other platforms, specifically aarch64, s390x
and ppc64le.

This commit fixes it by testing the library with 7 exbi.

Fixes #37