### PR TITLE
Replace math/rand usage with crypto/rand

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -1,9 +1,9 @@
 package random
 
 import (
-	"math/rand"
+	"bufio"
+	"crypto/rand"
 	"strings"
-	"time"
 )
 
 type (
@@ -27,7 +27,6 @@ var (
 )
 
 func New() *Random {
-	rand.Seed(time.Now().UnixNano())
 	return new(Random)
 }
 
@@ -36,11 +35,16 @@ func (r *Random) String(length uint8, charsets ...string) string {
 	if charset == "" {
 		charset = Alphanumeric
 	}
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Int63()%int64(len(charset))]
+	reader := bufio.NewReaderSize(rand.Reader, int(length))
+	buf := make([]byte, length)
+	for i := range buf {
+		b, err := reader.ReadByte()
+		if err != nil {
+			panic(err)
+		}
+		buf[i] = charset[int(b)%len(charset)]
 	}
-	return string(b)
+	return string(buf)
 }
 
 func String(length uint8, charsets ...string) string {


### PR DESCRIPTION
This replaces the usage of math/rand with crypto/rand to support downstream usages of the random package that have security implications, such as the csrf middleware.

I don't see it used a lot of places, the only place outside of the csrf middleware appears to be the request_id middleware. If it makes more sense to ensure performance for non-crypographic usage of this package (which request_id middleware appears to be), I can create a second type and constructor for `SecureRandom` that uses the crypto/rand source, leaving the existing behavior for the Random type. Just let me know what you prefer.