### PR TITLE
Update README.md

### DIFF
--- a/color/README.md
+++ b/color/README.md
@@ -14,8 +14,8 @@ Try [cmder](http://bliker.github.io/cmder) or https://github.com/mattn/go-colora
 
 ## [Usage](https://github.com/labstack/gommon/blob/master/color/color_test.go)
 
-```sh
-import github.com/labstack/gommon/color
+```go
+import "github.com/labstack/gommon/color"
 ```
 
 ### Colored text


### PR DESCRIPTION
Fixed syntax error in example code:

`import github.com/labstack/gommon/color` is invalid Go syntax because it omits quotes. Replaced with `import "github.com/labstack/gommon/color"`