### PR TITLE
Adapt tests for arm64

### DIFF
--- a/bytes/bytes_amd64_test.go
+++ b/bytes/bytes_amd64_test.go
@@ -1,0 +1,30 @@
+package bytes
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBytesParseEB(t *testing.T) {
+	// EB
+	b, err := Parse("8EB")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b-1)
+	}
+	b, err = Parse("8E")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b-1)
+	}
+
+	// EB with spaces
+	b, err = Parse("8 EB")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b-1)
+	}
+	b, err = Parse("8 E")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b-1)
+	}
+}

--- a/bytes/bytes_arm64_test.go
+++ b/bytes/bytes_arm64_test.go
@@ -1,0 +1,30 @@
+package bytes
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBytesParseEB(t *testing.T) {
+	// EB
+	b, err := Parse("8EB")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b)
+	}
+	b, err = Parse("8E")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b)
+	}
+
+	// EB with spaces
+	b, err = Parse("8 EB")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b)
+	}
+	b, err = Parse("8 E")
+	if assert.NoError(t, err) {
+		assert.True(t, math.MaxInt64 == b)
+	}
+}

--- a/bytes/bytes_test.go
+++ b/bytes/bytes_test.go
@@ -204,24 +204,4 @@ func TestBytesParse(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, int64(10133099161583616), b)
 	}
-
-	// EB
-	b, err = Parse("8EB")
-	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
-	}
-	b, err = Parse("8E")
-	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
-	}
-
-	// EB with spaces
-	b, err = Parse("8 EB")
-	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
-	}
-	b, err = Parse("8 E")
-	if assert.NoError(t, err) {
-		assert.True(t, math.MaxInt64 == b-1)
-	}
 }


### PR DESCRIPTION
All tests for "EB" fail on arm64:
```
--- FAIL: TestBytesParse (0.00s)
    bytes_test.go:211:
        	Error Trace:	bytes_test.go:211
        	Error:      	Should be true
        	Test:       	TestBytesParse
    bytes_test.go:215:
        	Error Trace:	bytes_test.go:215
        	Error:      	Should be true
        	Test:       	TestBytesParse
    bytes_test.go:221:
        	Error Trace:	bytes_test.go:221
        	Error:      	Should be true
        	Test:       	TestBytesParse
    bytes_test.go:225:
        	Error Trace:	bytes_test.go:225
        	Error:      	Should be true
        	Test:       	TestBytesParse
```

This is because the conversion from float64 to int64 is implementation specific (see https://github.com/golang/go/issues/45588). The test on arm64 should be `b == math.MaxInt64`.

This change moves the "EB" tests in platform-specific test files.