### PR TITLE
remove atomic operation in the logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -22,7 +21,7 @@ import (
 type (
 	Logger struct {
 		prefix     string
-		level      uint32
+		level      Lvl
 		skip       int
 		output     io.Writer
 		template   *fasttemplate.Template
@@ -59,7 +58,7 @@ func init() {
 
 func New(prefix string) (l *Logger) {
 	l = &Logger{
-		level:    uint32(INFO),
+		level:    INFO,
 		skip:     2,
 		prefix:   prefix,
 		template: l.newTemplate(defaultHeader),
@@ -111,11 +110,11 @@ func (l *Logger) SetPrefix(p string) {
 }
 
 func (l *Logger) Level() Lvl {
-	return Lvl(atomic.LoadUint32(&l.level))
+	return l.level
 }
 
 func (l *Logger) SetLevel(level Lvl) {
-	atomic.StoreUint32(&l.level, uint32(level))
+	l.level = level
 }
 
 func (l *Logger) Output() io.Writer {

--- a/log/log.go
+++ b/log/log.go
@@ -109,10 +109,12 @@ func (l *Logger) SetPrefix(p string) {
 	l.prefix = p
 }
 
+//go:norace
 func (l *Logger) Level() Lvl {
 	return l.level
 }
 
+//go:norace
 func (l *Logger) SetLevel(level Lvl) {
 	l.level = level
 }


### PR DESCRIPTION
I think these atomic operations in logger are not useful, reasons as below:
1. Usually, we should init logger level at the beginning of the process, before the service starts listening.
2. There are many goroutines calling logger methods, the atomic operations can only lock the level field but can not lock the logging processing steps which do not need to be guaranteed, and that should be a little waste of the performance.