### PR TITLE
add ParseLevel func to return level const

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -246,6 +247,24 @@ func SetPrefix(p string) {
 
 func Level() Lvl {
 	return global.Level()
+}
+
+func ParseLevel(lvl string) (Lvl, error) {
+	switch strings.ToUpper(lvl) {
+	case "DEBUG":
+		return DEBUG, nil
+	case "INFO":
+		return INFO, nil
+	case "WARN":
+		return WARN, nil
+	case "ERROR":
+		return ERROR, nil
+	case "OFF":
+		return OFF, nil
+	}
+
+	var l Lvl
+	return l, fmt.Errorf("not a valid log level: '%s'", lvl)
 }
 
 func SetLevel(level Lvl) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -73,6 +74,31 @@ func TestFatal(t *testing.T) {
 
 	loggerFatalTest(t, "fatal", "fatal")
 	loggerFatalTest(t, "fatalf", "fatal-f")
+}
+
+func TestParseLevel(t *testing.T) {
+	testCases := map[string]struct {
+		input       string
+		expectedLvl Lvl
+		expectedErr error
+	}{
+		"DEBUG":     {"DEBUG", DEBUG, nil},
+		"INFO":      {"INFO", INFO, nil},
+		"WARN":      {"WARN", WARN, nil},
+		"ERROR":     {"ERROR", ERROR, nil},
+		"OFF":       {"OFF", OFF, nil},
+		"lowercase": {"debug", DEBUG, nil},
+		"mixedcase": {"WaRn", WARN, nil},
+		"unknown":   {"UNKNOWN", 0, errors.New("not a valid log level: 'UNKNOWN'")},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			lvl, err := ParseLevel(testCase.input)
+			assert.Equal(t, testCase.expectedLvl, lvl)
+			assert.Equal(t, testCase.expectedErr, err)
+		})
+	}
 }
 
 func loggerFatalTest(t *testing.T, env string, contains string) {


### PR DESCRIPTION
this will allow consumers of this package to not have to do their own logic to convert known log levels to the constants defined for each one within this package.