### PR TITLE
feat(random): use crypto/rand for random string generator

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -30,6 +30,7 @@ var (
 )
 
 func New() *Random {
+	// https://tip.golang.org/doc/go1.19#:~:text=Read%20no%20longer%20buffers%20random%20data%20obtained%20from%20the%20operating%20system%20between%20calls
 	p := sync.Pool{New: func() interface{} {
 		return bufio.NewReader(rand.Reader)
 	}}

--- a/random/random.go
+++ b/random/random.go
@@ -57,8 +57,8 @@ func (r *Random) String(length uint8, charsets ...string) string {
 	var i uint8 = 0
 
 	// security note:
-	// we can't just simply do b[i]=randomStringCharset[rb%len(randomStringCharset)],
-	// for example, when len(charsets) is 52, and rb is [0, 255], 256 = 52 * 4 + 48.
+	// we can't just simply do b[i]=charset[rb%byte(charsetLen)],
+	// for example, when charsetLen is 52, and rb is [0, 255], 256 = 52 * 4 + 48.
 	// this will make the first 48 characters more possibly to be generated then others.
 	// so we have to skip bytes when rb > maxByte
 

--- a/random/random.go
+++ b/random/random.go
@@ -3,13 +3,29 @@ package random
 import (
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 )
 
 type (
 	Random struct {
+		lock sync.Mutex
+		src  rand.Source
 	}
 )
+
+func (r *Random) Int63() (n int64) {
+	r.lock.Lock()
+	n = r.src.Int63()
+	r.lock.Unlock()
+	return
+}
+
+func (r *Random) Seed(seed int64) {
+	r.lock.Lock()
+	r.src.Seed(seed)
+	r.lock.Unlock()
+}
 
 // Charsets
 const (
@@ -27,8 +43,8 @@ var (
 )
 
 func New() *Random {
-	rand.Seed(time.Now().UnixNano())
-	return new(Random)
+	src := rand.NewSource(time.Now().UnixNano())
+	return &Random{src: src}
 }
 
 func (r *Random) String(length uint8, charsets ...string) string {
@@ -38,7 +54,7 @@ func (r *Random) String(length uint8, charsets ...string) string {
 	}
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Int63()%int64(len(charset))]
+		b[i] = charset[r.Int63()%int64(len(charset))]
 	}
 	return string(b)
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"math/rand"
 	"regexp"
 	"testing"
 
@@ -11,6 +12,19 @@ func Test(t *testing.T) {
 	assert.Len(t, String(32), 32)
 	r := New()
 	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
+}
+
+func TestRandomString(t *testing.T) {
+	r := New()
+	// overwrite initialized Source by New()
+	rand.Seed(1)
+
+	got := r.String(32, Alphanumeric)
+	str := "onrHFkSuohOf8IvDIjS5HUHTGvw8q5mt"
+
+	if got == str {
+		t.Errorf("want random string; got: %s\n", got)
+	}
 }
 
 func BenchmarkRandomString(b *testing.B) {

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,7 +1,6 @@
 package random
 
 import (
-	"math/rand"
 	"regexp"
 	"testing"
 
@@ -11,20 +10,8 @@ import (
 func Test(t *testing.T) {
 	assert.Len(t, String(32), 32)
 	r := New()
-	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
-}
-
-func TestRandomString(t *testing.T) {
-	r := New()
-	// overwrite initialized Source by New()
-	rand.Seed(1)
-
-	got := r.String(32, Alphanumeric)
-	str := "onrHFkSuohOf8IvDIjS5HUHTGvw8q5mt"
-
-	if got == str {
-		t.Errorf("want random string; got: %s\n", got)
-	}
+	want := r.String(8, Numeric)
+	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), want)
 }
 
 func BenchmarkRandomString(b *testing.B) {

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -5,10 +5,63 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
 	assert.Len(t, String(32), 32)
 	r := New()
 	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
+}
+
+func TestRandomString(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		whenLength uint8
+		expect     string
+	}{
+		{
+			name:       "ok, 16",
+			whenLength: 16,
+		},
+		{
+			name:       "ok, 32",
+			whenLength: 32,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			uid := String(tc.whenLength, Alphabetic)
+			assert.Len(t, uid, int(tc.whenLength))
+		})
+	}
+}
+
+func TestRandomStringBias(t *testing.T) {
+	t.Parallel()
+	const slen = 33
+	const loop = 100000
+
+	counts := make(map[rune]int)
+	var count int64
+
+	for i := 0; i < loop; i++ {
+		s := String(slen, Alphabetic)
+		require.Equal(t, slen, len(s))
+		for _, b := range s {
+			counts[b]++
+			count++
+		}
+	}
+
+	require.Equal(t, len(Alphabetic), len(counts))
+
+	avg := float64(count) / float64(len(counts))
+	for k, n := range counts {
+		diff := float64(n) / avg
+		if diff < 0.95 || diff > 1.05 {
+			t.Errorf("Bias on '%c': expected average %f, got %d", k, avg, n)
+		}
+	}
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,7 +1,6 @@
 package random
 
 import (
-	"math/rand"
 	"regexp"
 	"testing"
 
@@ -12,19 +11,6 @@ func Test(t *testing.T) {
 	assert.Len(t, String(32), 32)
 	r := New()
 	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
-}
-
-func TestRandomString(t *testing.T) {
-	r := New()
-	// overwrite initialized Source by New()
-	rand.Seed(1)
-
-	got := r.String(32, Alphanumeric)
-	str := "onrHFkSuohOf8IvDIjS5HUHTGvw8q5mt"
-
-	if got == str {
-		t.Errorf("want random string; got: %s\n", got)
-	}
 }
 
 func BenchmarkRandomString(b *testing.B) {

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -12,9 +12,3 @@ func Test(t *testing.T) {
 	r := New()
 	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
 }
-
-func BenchmarkRandomString(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		String(32, Alphanumeric)
-	}
-}

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -12,3 +12,9 @@ func Test(t *testing.T) {
 	r := New()
 	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
 }
+
+func BenchmarkRandomString(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		String(32, Alphanumeric)
+	}
+}

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"math/rand"
 	"regexp"
 	"testing"
 
@@ -10,8 +11,20 @@ import (
 func Test(t *testing.T) {
 	assert.Len(t, String(32), 32)
 	r := New()
-	want := r.String(8, Numeric)
-	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), want)
+	assert.Regexp(t, regexp.MustCompile("[0-9]+$"), r.String(8, Numeric))
+}
+
+func TestRandomString(t *testing.T) {
+	r := New()
+	// overwrite initialized Source by New()
+	rand.Seed(1)
+
+	got := r.String(32, Alphanumeric)
+	str := "onrHFkSuohOf8IvDIjS5HUHTGvw8q5mt"
+
+	if got == str {
+		t.Errorf("want random string; got: %s\n", got)
+	}
 }
 
 func BenchmarkRandomString(b *testing.B) {


### PR DESCRIPTION
The current implementation for `random` package relied on globally seeded value. 
If any other part of the programs call `rand.Seed`, the string generate by `random` package will also be affected.

~~To fix this issue, instead of calling `rand.Seed` during initialization, `NewSource` is called and the return value is stored inside `Random` struct.~~

I made changes by referring to the source code from the link below.
https://github.com/labstack/echo/blob/e6b96f8873fed46e71e0d34cddb81c533167f954/middleware/util.go#L69 

I also did some benchmarks before and after the update.

Before

```
goos: linux
goarch: amd64
pkg: github.com/labstack/gommon/random
cpu: Intel(R) Core(TM) i7-4702MQ CPU @ 2.20GHz
BenchmarkRandomString-8   	 1472410	       806.7 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1478504	       812.3 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1484530	       806.4 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1470031	       801.5 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1492831	       809.4 ns/op	      64 B/op	       2 allocs/op
```

After (with sync.Mutex)

```
goos: linux
goarch: amd64
pkg: github.com/labstack/gommon/random
cpu: Intel(R) Core(TM) i7-4702MQ CPU @ 2.20GHz
BenchmarkRandomString-8   	 1507052	       771.5 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1549957	       775.3 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1519629	       774.4 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1540794	       774.6 ns/op	      64 B/op	       2 allocs/op
BenchmarkRandomString-8   	 1548172	       777.5 ns/op	      64 B/op	       2 allocs/op
```

After (with sync.Pool)

```
goos: linux
goarch: amd64
pkg: github.com/labstack/gommon/random
cpu: Intel(R) Core(TM) i7-4702MQ CPU @ 2.20GHz
BenchmarkRandomString-8   	 2655366	       446.7 ns/op	     112 B/op	       3 allocs/op
BenchmarkRandomString-8   	 2629251	       451.6 ns/op	     112 B/op	       3 allocs/op
BenchmarkRandomString-8   	 2613632	       456.5 ns/op	     112 B/op	       3 allocs/op
BenchmarkRandomString-8   	 2638729	       458.5 ns/op	     112 B/op	       3 allocs/op
BenchmarkRandomString-8   	 2577884	       462.6 ns/op	     112 B/op	       3 allocs/op
```